### PR TITLE
Add window_manager_change signal callback to update label in such cases.

### DIFF
--- a/applets/wnck/deskno/deskno.vala
+++ b/applets/wnck/deskno/deskno.vala
@@ -53,9 +53,8 @@ public class Deskno: Applet
         this.notify.connect((pspec)=>{
             name_update();
         });
-        screen_handler = Wnck.Screen.get_default().active_workspace_changed.connect(()=>{
-            name_update();
-        });
+        screen_handler = Wnck.Screen.get_default().active_workspace_changed.connect(name_update);
+        screen_handler = Wnck.Screen.get_default().window_manager_changed.connect(name_update);
         name_update();
         this.add(label);
         this.show_all();


### PR DESCRIPTION
Hello,
This PR makes the "deskno" applet able to update the workspace label when the Window Manager has changed, such that it can not happen that we display a previously defined and possibly outdated label.
In my case, gdm (mutter) loads i3 with vala-panel which displays "Workspace 1" instead of the i3 defined "1" (plus some funky chars ^^) label, and it stays until I trigger a desktop switch or modify some watched parameters.
This seems to happen because WnckScreen workspaces names can sometimes not be updated before the constructor of Deskno calls update_name() (L.58).